### PR TITLE
Better handle producer errors

### DIFF
--- a/Rinkudesu.Kafka.Dotnet.IntegrationTests/KafkaConnectionTests.cs
+++ b/Rinkudesu.Kafka.Dotnet.IntegrationTests/KafkaConnectionTests.cs
@@ -55,11 +55,12 @@ public sealed class KafkaConnectionTests : IAsyncDisposable
 
         _subscriber.Subscribe(_messageHandler);
         _subscriber.BeginHandle(handleCancellationToken.Token);
-        _producer.ProduceBulk(_messageHandler.Topic, messages, TimeSpan.FromSeconds(5));
+        var result = _producer.ProduceBulk(_messageHandler.Topic, messages, TimeSpan.FromSeconds(5));
         await Task.Delay(TimeSpan.FromSeconds(10), CancellationToken.None); //wait for messages to definitely circulate
         await _subscriber.Unsubscribe();
 
         Assert.Equal(msgCount, _messageHandler.HandleCount);
+        Assert.True(result);
     }
 
     public async ValueTask DisposeAsync()

--- a/Rinkudesu.Kafka.Dotnet/Base/IKafkaProducer.cs
+++ b/Rinkudesu.Kafka.Dotnet/Base/IKafkaProducer.cs
@@ -25,10 +25,11 @@ public interface IKafkaProducer : IDisposable
     /// <param name="messages">The collection of messages.</param>
     /// <param name="waitTime">Maximum time to wait for all messages to be sent. If <see langword="null"/>, an arbitrary value will be used.</param>
     /// <typeparam name="T">Type of the messages to enqueue.</typeparam>
+    /// <returns><c>true</c> if all messages were successfully flushed to Kafka, <c>false</c> if some still remain.</returns>
     /// <remarks>
     /// This message should be faster than <see cref="Produce{T}"/> as it does not wait for any single message to be enqueued.
     /// Due to this fact, it should only be used when speed is a major concern.
     /// If many messages need to be sent, but speed is not an issue in the relevant scenario, consider using <see cref="Produce{T}"/> in a loop instead.
     /// </remarks>
-    void ProduceBulk<T>(string topic, IEnumerable<T> messages, TimeSpan? waitTime = null) where T : GenericKafkaMessage;
+    bool ProduceBulk<T>(string topic, IEnumerable<T> messages, TimeSpan? waitTime = null) where T : GenericKafkaMessage;
 }

--- a/Rinkudesu.Kafka.Dotnet/KafkaProducer.cs
+++ b/Rinkudesu.Kafka.Dotnet/KafkaProducer.cs
@@ -53,7 +53,7 @@ public class KafkaProducer : IKafkaProducer
         }
         finally
         {
-            flushed = _producer.Flush(waitTime ?? TimeSpan.FromSeconds(10)) > 0;
+            flushed = _producer.Flush(waitTime ?? TimeSpan.FromSeconds(10)) == 0;
         }
 
         if (exceptions.Any()) throw new AggregateException(exceptions);

--- a/Rinkudesu.Kafka.Dotnet/KafkaProducer.cs
+++ b/Rinkudesu.Kafka.Dotnet/KafkaProducer.cs
@@ -19,7 +19,8 @@ public class KafkaProducer : IKafkaProducer
     {
         try
         {
-            await _producer.ProduceAsync(topic, message.GetMessage(), cancellationToken).ConfigureAwait(false);
+            var result = await _producer.ProduceAsync(topic, message.GetMessage(), cancellationToken).ConfigureAwait(false);
+            if (result.Status != PersistenceStatus.Persisted) throw new KafkaProduceException("Failed to persist message.");
         }
         catch (ProduceException<Null, string> e)
         {
@@ -32,8 +33,9 @@ public class KafkaProducer : IKafkaProducer
     /// Thrown when sending of at least one message has failed. Will contain <see cref="KafkaProduceException"/> thrown during sending.
     /// Note that all messages will attempt to send, regardless of when the first exception was thrown.
     /// </exception>
-    public virtual void ProduceBulk<T>(string topic, IEnumerable<T> messages, TimeSpan? waitTime = null) where T : GenericKafkaMessage
+    public virtual bool ProduceBulk<T>(string topic, IEnumerable<T> messages, TimeSpan? waitTime = null) where T : GenericKafkaMessage
     {
+        bool flushed;
         var exceptions = new LinkedList<KafkaProduceException>();
         try
         {
@@ -51,10 +53,11 @@ public class KafkaProducer : IKafkaProducer
         }
         finally
         {
-            _producer.Flush(waitTime ?? TimeSpan.FromSeconds(10));
+            flushed = _producer.Flush(waitTime ?? TimeSpan.FromSeconds(10)) > 0;
         }
 
         if (exceptions.Any()) throw new AggregateException(exceptions);
+        return flushed;
     }
 
     protected virtual void Dispose(bool disposing)


### PR DESCRIPTION
Closes #3 

Adds better handling of `IKafkaProducer` errors, as so far a successful delivery was not verified in any way.