### PR TITLE
Use bitnami docker image in tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,7 @@ jobs:
     steps:
       - name: Start Kafka Docker containers
         run: |
-          wget -O ./kafka.docker-compose.yml https://raw.githubusercontent.com/rinkudesu/kafka-docker/main/docker-compose.yml
-          docker compose -f kafka.docker-compose.yml up -d
+          docker compose -f ./Rinkudesu.Kafka.Dotnet.IntegrationTests/docker-compose.yml up -d
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,9 +10,6 @@ jobs:
     name: Build and test with Sonar
     runs-on: ubuntu-latest
     steps:
-      - name: Start Kafka Docker containers
-        run: |
-          docker compose -f ./Rinkudesu.Kafka.Dotnet.IntegrationTests/docker-compose.yml up -d
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
@@ -21,6 +18,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Start Kafka Docker containers
+        run: |
+          docker compose -f ./Rinkudesu.Kafka.Dotnet.IntegrationTests/docker-compose.yml up -d
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
         with:

--- a/.github/workflows/nuget-push.yml
+++ b/.github/workflows/nuget-push.yml
@@ -12,8 +12,7 @@ jobs:
 
       - name: Start Kafka Docker containers
         run: |
-          wget -O ./kafka.docker-compose.yml https://raw.githubusercontent.com/rinkudesu/kafka-docker/main/docker-compose.yml
-          docker compose -f kafka.docker-compose.yml up -d
+          docker compose -f ./Rinkudesu.Kafka.Dotnet.IntegrationTests/docker-compose.yml up -d
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v3

--- a/Rinkudesu.Kafka.Dotnet.IntegrationTests/docker-compose.yml
+++ b/Rinkudesu.Kafka.Dotnet.IntegrationTests/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "2"
+
+services:
+  zookeeper:
+    image: docker.io/bitnami/zookeeper
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+      - KAFKA_TLS_CLIENT_AUTH=none
+  kafka:
+    image: docker.io/bitnami/kafka
+    ports:
+      - "127.0.0.1:9092:9092"
+    environment:
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://127.0.0.1:9092
+    depends_on:
+      - zookeeper


### PR DESCRIPTION
In accordance with https://github.com/rinkudesu/kafka-docker/issues/10, the Kafka docker is replaced with the Bitnami image.