### PR TITLE
Dispose kafka consumer and catch object disposed exceptions to prevent double disposal issues

### DIFF
--- a/Rinkudesu.Kafka.Dotnet/Helpers.cs
+++ b/Rinkudesu.Kafka.Dotnet/Helpers.cs
@@ -1,0 +1,24 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Rinkudesu.Kafka.Dotnet;
+
+internal static class Helpers
+{
+    /// <summary>
+    /// Tries do dispose an object using <paramref name="disposeAction"/> and handles <see cref="ObjectDisposedException"/>.
+    /// </summary>
+    /// <param name="disposing">Object to be disposed using <paramref name="disposeAction"/></param>
+    /// <param name="disposeAction">Action that disposes of an object, that might throw <see cref="ObjectDisposedException"/>.</param>
+    [ExcludeFromCodeCoverage]
+    internal static void EnsureDisposed<T>(T disposing, Action<T> disposeAction)
+    {
+        try
+        {
+            disposeAction(disposing);
+        }
+        catch (ObjectDisposedException)
+        {
+            // this means that this object has already been disposed, which is fine
+        }
+    }
+}

--- a/Rinkudesu.Kafka.Dotnet/KafkaSubscriber.cs
+++ b/Rinkudesu.Kafka.Dotnet/KafkaSubscriber.cs
@@ -141,8 +141,8 @@ public class KafkaSubscriber<T> : IKafkaSubscriber<T> where T : GenericKafkaMess
         if (disposing)
         {
             await Unsubscribe().ConfigureAwait(false);
-            _consumer.Close();
-            _consumer.Dispose();
+            Helpers.EnsureDisposed(_consumer, c => c.Close());
+            Helpers.EnsureDisposed(_consumer, c => c.Dispose());
             _cancellationTokenSource?.Dispose();
             _combinedTaskCancellation?.Dispose();
         }


### PR DESCRIPTION
I don't really have a way of testing this, so will need to wait for the release to see how that behaves.

(Hopefully) closes #44.